### PR TITLE
デプロイ方法の変更

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -7,10 +7,10 @@ app_path = File.expand_path('../../../', __FILE__)
 # stderr_path "#{app_path}/log/unicorn.stderr.log"
 # stdout_path "#{app_path}/log/unicorn.stdout.log"
 
-working_directory "#{app_path}/current"
+working_directory "#{app_path}/tmp/pids/unicorn.pid"
 pid "#{app_path}/shared/tmp/pids/unicorn.pid"
-stderr_path "#{app_path}/shared/log/unicorn.stderr.log"
-stdout_path "#{app_path}/shared/log/unicorn.stdout.log"
+stderr_path "#{app_path}/log/unicorn.stderr.log"
+stdout_path "#{app_path}/log/unicorn.stdout.log"
 
 listen 3000
 timeout 60


### PR DESCRIPTION
# WHAT
・ユニコーンのパスの変更
# WHY
capstranoでデプロイがうまくいかず、デプロイ方法を一時的に変更するため