### PR TITLE
デプロイのための調整

### DIFF
--- a/app/uploaders/images_uploader.rb
+++ b/app/uploaders/images_uploader.rb
@@ -10,7 +10,7 @@ class ImagesUploader < CarrierWave::Uploader::Base
   process resize_to_limit: [500, 500]
 
   # Choose what kind of storage to use for this uploader:
-  strage :fog
+  # strage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:


### PR DESCRIPTION
# WHAT
images_uploaderのstorageのコメントアウト
# WHY
デプロイのエラーの原因を絞るために、ターミナルでエラーがでる部分をコメントアウトした。