### PR TITLE
デプロイに向けたビューと画像アップロード機能の調整

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 /tmp
 
 *.log
+
+log/capistrano.log
+
+log/development.log

--- a/app/assets/stylesheets/_article.scss
+++ b/app/assets/stylesheets/_article.scss
@@ -630,6 +630,7 @@ html{
   width: 80%;
   height: 1000px;
   &-top{
+    margin-top: 40px;
     background-color: #EAEAEA;
     &__user {
       &__info{

--- a/app/assets/stylesheets/_article.scss
+++ b/app/assets/stylesheets/_article.scss
@@ -249,7 +249,7 @@ html{
     &-right {
       height: 100%;
       width: 34%;
-      float: left;
+      float: right;
       &-top {
         height: 50%;
         width: 100%;

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -7,9 +7,8 @@ class ArticlesController < ApplicationController
     # articles = Article.al3
     # @articles = articles.order("articles.picks.last.id DESC").limit(15)
     @article = Article.new
-    @picks = Pick.all.order("updated_at DESC").uniq(:id).limit(15)
-    # binding.pry
-    @articles = Article.all.order("updated_at DESC").uniq(:id).limit(15)
+    @picks = Pick.all.order("updated_at DESC").uniq(:id).limit(20)
+    @articles = Article.all.order("updated_at DESC").uniq(:id).limit(60)
   end
 
   def show

--- a/app/uploaders/images_uploader.rb
+++ b/app/uploaders/images_uploader.rb
@@ -5,12 +5,12 @@ class ImagesUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
   include CarrierWave::MiniMagick
 
-  # strage :file
+  storage :fog if Rails.env.production?
 
   process resize_to_limit: [500, 500]
 
   # Choose what kind of storage to use for this uploader:
-  # strage :fog
+
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,5 +1,7 @@
 .header
 .content
+  .contents__back
+    =link_to "←総合トップ", root_path, class: 'contents__back__root'
   .content-top
     .content-top__user
       .content-top__user__info.clearfix


### PR DESCRIPTION
# WHAT
・top画像レイアウトのズレ調整
・ビューに表示する記事の数を増やした。
・画像のアップロード先を変更
・userページにルートパスへのリンクを設定。
# WHY
・デプロイしたものを人に見せれる状態のものにするため。